### PR TITLE
Add ability to enable Metric Timestamp

### DIFF
--- a/src/HttpRequestDurationsMiddleware.cs
+++ b/src/HttpRequestDurationsMiddleware.cs
@@ -40,7 +40,7 @@ namespace Prometheus.Client.HttpRequestDurations
                 labels.AddRange(_options.CustomLabels.Select(customLabel => customLabel.Key));
 
             _metricHelpText += string.Join(", ", labels);
-            _histogram = metricFactory.CreateHistogram(options.MetricName, _metricHelpText, options.MetricTimestamp, options.Buckets, labels.ToArray());
+            _histogram = metricFactory.CreateHistogram(options.MetricName, _metricHelpText, options.IncludeTimestamp, options.Buckets, labels.ToArray());
         }
 
         public async Task Invoke(HttpContext context)

--- a/src/HttpRequestDurationsMiddleware.cs
+++ b/src/HttpRequestDurationsMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -40,7 +40,7 @@ namespace Prometheus.Client.HttpRequestDurations
                 labels.AddRange(_options.CustomLabels.Select(customLabel => customLabel.Key));
 
             _metricHelpText += string.Join(", ", labels);
-            _histogram = metricFactory.CreateHistogram(options.MetricName, _metricHelpText, _options.Buckets, labels.ToArray());
+            _histogram = metricFactory.CreateHistogram(options.MetricName, _metricHelpText, options.MetricTimestamp, options.Buckets, labels.ToArray());
         }
 
         public async Task Invoke(HttpContext context)

--- a/src/HttpRequestDurationsOptions.cs
+++ b/src/HttpRequestDurationsOptions.cs
@@ -17,6 +17,13 @@ namespace Prometheus.Client.HttpRequestDurations
         public string MetricName { get; set; }
 
         /// <summary>
+        ///     <para>When true; the timestamp is added to the metric.</para>
+        ///     <para>When false; the timestamp is NOT added.</para>
+        ///     <para>Defaults to false.</para>
+        /// </summary>
+        public bool MetricTimestamp { get; set; } = false;
+
+        /// <summary>
         ///     HTTP status code (200, 400, 404 etc.)
         /// </summary>
         public bool IncludeStatusCode { get; set; }

--- a/src/HttpRequestDurationsOptions.cs
+++ b/src/HttpRequestDurationsOptions.cs
@@ -21,7 +21,7 @@ namespace Prometheus.Client.HttpRequestDurations
         ///     <para>When false; the timestamp is NOT added.</para>
         ///     <para>Defaults to false.</para>
         /// </summary>
-        public bool MetricTimestamp { get; set; } = false;
+        public bool IncludeTimestamp { get; set; } = false;
 
         /// <summary>
         ///     HTTP status code (200, 400, 404 etc.)


### PR DESCRIPTION
Enable ability to enable metric timestamps

Provides an option that can be enabled to add the timestamp capability to the metrics that are output.  Defaults to off (false) -- which is the existing behavior.

https://prometheus.io/docs/instrumenting/exposition_formats/
```
metric_name [
  "{" label_name "=" `"` label_value `"` { "," label_name "=" `"` label_value `"` } [ "," ] "}"
] value [ timestamp ]
```